### PR TITLE
wrap data in single quotes

### DIFF
--- a/src/lib/CurlHelper.js
+++ b/src/lib/CurlHelper.js
@@ -26,8 +26,7 @@ export class CurlHelper {
 
     getBody() {
         let data = (typeof this.request.data === 'object' || typeof this.request.data === 'array') ? JSON.stringify(this.request.data) : this.request.data;
-        return `--data ${data}`.trim();
-        
+        return `--data '${data}'`.trim();
     }
 
     getUrl() {

--- a/src/test/curlirize.test.js
+++ b/src/test/curlirize.test.js
@@ -25,7 +25,7 @@ describe('Testing curlirize', () => {
         axios.post('http://localhost:7500/', {dummy: 'data'})
         .then((res) => {
             expect(res.config.curlCommand).toBeDefined();
-            expect(res.config.curlCommand).toBe('curl -X POST -H "Content-Type:application/x-www-form-urlencoded" --data {"dummy":"data"} http://localhost:7500/');
+            expect(res.config.curlCommand).toBe('curl -X POST -H "Content-Type:application/x-www-form-urlencoded" --data \'{"dummy":"data"}\' http://localhost:7500/');
             done();
         })
         .catch((err) => {
@@ -62,7 +62,7 @@ describe('Testing curl-helper module', () => {
     });
 
     it('should return a string with request body', (done) => {
-        expect(curl.getBody()).toBe('--data {"dummy":"data"}');
+        expect(curl.getBody()).toBe('--data \'{"dummy":"data"}\'');
         done();
     });
 


### PR DESCRIPTION
@delirius325 cURL commands fail for me on OS X 10.13 using bash without having the data as json wrapped in single quotes.