### PR TITLE
Fix invalid typeof for check array

### DIFF
--- a/src/lib/CurlHelper.js
+++ b/src/lib/CurlHelper.js
@@ -33,7 +33,7 @@ export class CurlHelper {
 
   getBody() {
     if((typeof this.request.data !== 'undefined') && this.request.data !== '' && Object.keys(this.request.data).length && this.request.method.toUpperCase() !== 'GET') {
-      let data = (typeof this.request.data === 'object' || typeof this.request.data === 'array') ? JSON.stringify(this.request.data) : this.request.data;
+      let data = (typeof this.request.data === 'object' ||  Object.prototype.toString.call(this.request.data) === '[object Array]') ? JSON.stringify(this.request.data) : this.request.data;
       return `--data '${data}'`.trim();
     } else {
       return '';


### PR DESCRIPTION
For a vast majority of use cases, the result of the typeof operator is one of the following string literals: "undefined", "object", "boolean", "number", "string", "function" and "symbol". It is usually a typing mistake to compare the result of a typeof operator to other string literals.

Use another way to check array.