### PR TITLE
Fix problems when axios-curlirize is a dependency of a dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/curlirize');
+module.exports = require('./src/curlirize');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
-    "postinstall": "if [ ! -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi"
+    "postinstall": "if [ -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Axios third-party module to print all axios requests as curl commands in the console.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js"
+    "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
+    "postinstall": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./src"
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,7 @@
   },
   "homepage": "https://github.com/delirius325/axios-curlirize#readme",
   "dependencies": {
+        "babel-core": "^6.26.0",
   },
   "devDependencies": {
     "axios": ">=0.19.0",
@@ -37,7 +39,6 @@
     "express": "^4.16.3",
     "mocha": "^5.2.0",
     "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1"
   }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Axios third-party module to print all axios requests as curl commands in the console.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
-    "postinstall": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./src"
+    "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
-    "postinstall": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./src"
+    "postinstall": "if [ ! -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi"
   },
   "repository": {
     "type": "git",
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/delirius325/axios-curlirize#readme",
   "dependencies": {
-        "babel-core": "^6.26.0",
   },
   "devDependencies": {
     "axios": ">=0.19.0",
@@ -39,6 +38,7 @@
     "express": "^4.16.3",
     "mocha": "^5.2.0",
     "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1"
   }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Axios third-party module to print all axios requests as curl commands in the console.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/babel  ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
-    "postinstall": "./node_modules/.bin/babel  ./src --experimental --source-maps-inline -d ./dist"
+    "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
+    "postinstall": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./src"
   },
   "repository": {
     "type": "git",

--- a/src/lib/CurlHelper.js
+++ b/src/lib/CurlHelper.js
@@ -45,6 +45,6 @@ export class CurlHelper {
   }
 
   generateCommand() {
-    return `curl ${this.getMethod()} ${this.getHeaders()} ${this.getBody()} ${this.getUrl()}`.trim().replace(/\s{2,}/g, ' ');
+    return `curl ${this.getMethod()} ${this.getHeaders()} ${this.getBody()} "${this.getUrl()}"`.trim().replace(/\s{2,}/g, ' ');
   }
 }


### PR DESCRIPTION
Hey

There are a couple of minor problems with the library when it is a dep of a dep that this pull fixes 

1) The package has a dev dependency on babel core, but it is used in a post install script that will be run on every npm/yarn install. This means that any project that depends on a dependency that has this as a dependency will need to have babel core or it will fail the install. Babel core is not required for the project to run at all so it is correct to keep it as a dev dep instead of promoting it to a dep. The fix i have put in checks to see if the file exists before running the post install script - however - this will only work on Nix systems, BUT i don't see this is a problem given CURL is not a windows command.

2) The package is pointing at /dist in its main export, but that folder does not exist in the NPM package or the git, causing a fail.

3) And then not related to all of that - the change to src/lib/CurlHelper.js makes it so that a command like this:

`curl -X GET -H "Authorization:Token a32e3eb775789988b2db9118ba10b824fe1b6781" localhost:8000/jafas/jafas/feed/?order=latest&page_size=20&page=1&date_range=`

will appear like this:

`curl -X GET -H "Authorization:Token a32e3eb775789988b2db9118ba10b824fe1b6781" "localhost:8000/jafas/jafas/feed/?order=latest&page_size=20&page=1&date_range="`

where the first command is invalid (it will error on Linux / Mac)

Happy days :)