### PR TITLE
#20 Fixed using axios-curlirize on node app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,3 @@ typings/
 # next.js build output
 .next
 
-# dist folder
-dist/

--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@
 
 This module is an axios third-party module to log any axios request as a curl command in the console. It was originally posted as a suggestion on the axios repository, but since we believed it wasn't in the scope of axios to release such feature, we decided to make it as an independent module.
 
-#Post Note:
-Axios third-party module to print all axios requests as curl commands in the console. This repository is forked from axios-curlirize <https://www.npmjs.com/package/axios-curlirize> and supports use with Node JS without having to enable ES6 imports. This repo was inspired by an issue <https://github.com/delirius325/axios-curlirize/issues/20> raised on the origional repository <https://github.com/delirius325/axios-curlirize>.
-
-Special thanks to Anthony Gauthier <https://github.com/delirius325>, the author of axios-curlirize.
-
-The package name hereafter will be referred to as axios-curlirize as I have contributed very little, for me change its name.
-
 # How it works
 
 The module makes use of axios' interceptors to log the request as a cURL command. It also stores it in the response's config object. Therefore, the command can be seen in the app's console, as well as in the `res.config.curlCommand` property of the response.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Axios third-party module to print all axios requests as curl commands in the con
 
 Special thanks to Anthony Gauthier <https://github.com/delirius325>, the author of axios-curlirize.
 
-The repository hereafter will be referred to as axios-curlirize as I have contributed very little, for me change its name.
+The package name hereafter will be referred to as axios-curlirize as I have contributed very little, for me change its name.
 
 # How it works
 

--- a/README.md
+++ b/README.md
@@ -3,61 +3,75 @@
 [![npm version](https://badge.fury.io/js/axios-curlirize.svg)](https://badge.fury.io/js/axios-curlirize)
 
 # Description
+
 This module is an axios third-party module to log any axios request as a curl command in the console. It was originally posted as a suggestion on the axios repository, but since we believed it wasn't in the scope of axios to release such feature, we decided to make it as an independent module.
 
+#Post Note:
+Axios third-party module to print all axios requests as curl commands in the console. This repository is forked from axios-curlirize <https://www.npmjs.com/package/axios-curlirize> and supports use with Node JS without having to enable ES6 imports. This repo was inspired by an issue <https://github.com/delirius325/axios-curlirize/issues/20> raised on the origional repository <https://github.com/delirius325/axios-curlirize>.
+
+Special thanks to Anthony Gauthier <https://github.com/delirius325>, the author of axios-curlirize.
+
+The repository hereafter will be referred to as axios-curlirize as I have contributed very little, for me change its name.
+
 # How it works
-The module makes use of axios' interceptors to log the request as a cURL command. It also stores it in the response's config object. Therefore, the command can be seen in the app's console, as well as in the ```res.config.curlCommand``` property of the response.
+
+The module makes use of axios' interceptors to log the request as a cURL command. It also stores it in the response's config object. Therefore, the command can be seen in the app's console, as well as in the `res.config.curlCommand` property of the response.
 
 # Changing the logger
+
 By default, axios-curlirize uses the `console.log/error()` functions. It is possible to change the logger by doing something similar to this:
 
 ```javascript
 // when initiating your curlirize instance
-curlirize(axios, (result, err) => {
-    const { command } = result;
-    if(err) {
-        // use your logger here
-    } else {
-        // use your logger here
-    }
+curlirize(axios, (result, err) => {
+  const { command } = result;
+  if (err) {
+    // use your logger here
+  } else {
+    // use your logger here
+  }
 });
 ```
 
 # How to use it
+
 axios-curlirize is super easy to use. First you'll have to install it.
+
 ```shell
 npm i --save axios-curlirize@latest
 ```
+
 Then all you have to do is import and instanciate curlirize in your app. Here's a sample:
 
 ```javascript
-    import axios from 'axios';
-    import express from 'express';
-    import curlirize from 'axios-curlirize';
+import axios from 'axios';
+import express from 'express';
+import curlirize from 'axios-curlirize';
 
-    const app = express();
+const app = express();
 
-    // initializing axios-curlirize with your axios instance
-    curlirize(axios);
+// initializing axios-curlirize with your axios instance
+curlirize(axios);
 
-    // creating dummy route
-    app.post('/', (req, res) => {
-        res.send({hello: 'world!'})
-    });
+// creating dummy route
+app.post('/', (req, res) => {
+  res.send({ hello: 'world!' });
+});
 
-    // starting server
-    app.listen(7500, () => {
-        console.log('Dummy server started on port 7500')
-        /*
+// starting server
+app.listen(7500, () => {
+  console.log('Dummy server started on port 7500');
+  /*
              The output of this in the console will be :
              curl -X POST -H "Content-Type:application/x-www-form-urlencoded" --data {"dummy":"data"} http://localhost:7500/
         */
-        axios.post('http://localhost:7500/', {dummy: 'data'})
-            .then((res) => {
-                console.log('success');
-            })
-            .catch((err) => {
-                console.log(err);
-            });
-    });    
+  axios
+    .post('http://localhost:7500/', { dummy: 'data' })
+    .then(res => {
+      console.log('success');
+    })
+    .catch(err => {
+      console.log(err);
+    });
+});
 ```

--- a/dist/curlirize.js
+++ b/dist/curlirize.js
@@ -1,0 +1,39 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _CurlHelper = require('./lib/CurlHelper');
+
+// thanks to https://github.com/uyu423
+function defaultLogCallback(curlResult, err) {
+  var command = curlResult.command;
+
+  if (err) {
+    console.error(err);
+  } else {
+    console.info(command);
+  }
+}
+
+exports.default = function (instance) {
+  var callback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultLogCallback;
+
+  instance.interceptors.request.use(function (req) {
+    try {
+      var curl = new _CurlHelper.CurlHelper(req);
+      req.curlObject = curl;
+      req.curlCommand = curl.generateCommand();
+    } catch (err) {
+      // Even if the axios middleware is stopped, no error should occur outside.
+      callback(null, err);
+    } finally {
+      callback({
+        command: req.curlCommand,
+        object: req.curlObject
+      });
+      return req;
+    }
+  });
+};

--- a/dist/lib/CurlHelper.js
+++ b/dist/lib/CurlHelper.js
@@ -1,0 +1,102 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var CurlHelper = exports.CurlHelper = function () {
+  function CurlHelper(config) {
+    _classCallCheck(this, CurlHelper);
+
+    this.request = config;
+  }
+
+  _createClass(CurlHelper, [{
+    key: "getHeaders",
+    value: function getHeaders() {
+      var headers = this.request.headers,
+          curlHeaders = "";
+
+      // get the headers concerning the appropriate method (defined in the global axios instance)
+      if (headers.hasOwnProperty("common")) {
+        headers = this.request.headers[this.request.method];
+      }
+
+      // add any custom headers (defined upon calling methods like .get(), .post(), etc.)
+      for (var property in this.request.headers) {
+        if (!["common", "delete", "get", "head", "patch", "post", "put"].includes(property)) {
+          headers[property] = this.request.headers[property];
+        }
+      }
+
+      for (var _property in headers) {
+        var header = _property + ":" + headers[_property];
+        curlHeaders = curlHeaders + " -H \"" + header + "\"";
+      }
+
+      return curlHeaders.trim();
+    }
+  }, {
+    key: "getMethod",
+    value: function getMethod() {
+      return "-X " + this.request.method.toUpperCase();
+    }
+  }, {
+    key: "getBody",
+    value: function getBody() {
+      if (typeof this.request.data !== "undefined" && this.request.data !== "" && Object.keys(this.request.data).length && this.request.method.toUpperCase() !== "GET") {
+        var data = _typeof(this.request.data) === "object" || Object.prototype.toString.call(this.request.data) === "[object Array]" ? JSON.stringify(this.request.data) : this.request.data;
+        return ("--data '" + data + "'").trim();
+      } else {
+        return "";
+      }
+    }
+  }, {
+    key: "getUrl",
+    value: function getUrl() {
+      return this.request.url;
+    }
+  }, {
+    key: "getQueryString",
+    value: function getQueryString() {
+      var params = "",
+          i = 0;
+
+      for (var param in this.request.params) {
+        if (i != 0) {
+          params += "&" + param + "=" + this.request.params[param];
+        } else {
+          params = "?" + param + "=" + this.request.params[param];
+        }
+        i++;
+      }
+
+      return params;
+    }
+  }, {
+    key: "getBuiltURL",
+    value: function getBuiltURL() {
+      var url = this.getUrl();
+
+      if (this.getQueryString() != "") {
+        url = url.charAt(url.length - 1) == '/' ? url.substr(0, url.length - 1) : url;
+        url += this.getQueryString();
+      }
+
+      return url.trim();
+    }
+  }, {
+    key: "generateCommand",
+    value: function generateCommand() {
+      return ("curl " + this.getMethod() + " " + this.getHeaders() + " " + this.getBody() + " \"" + this.getBuiltURL() + "\"").trim().replace(/\s{2,}/g, " ");
+    }
+  }]);
+
+  return CurlHelper;
+}();

--- a/dist/test/curlirize.test.js
+++ b/dist/test/curlirize.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+var _expect = require('expect');
+
+var _expect2 = _interopRequireDefault(_expect);
+
+var _axios = require('axios');
+
+var _axios2 = _interopRequireDefault(_axios);
+
+var _curlirize = require('../curlirize');
+
+var _curlirize2 = _interopRequireDefault(_curlirize);
+
+var _CurlHelper = require('../lib/CurlHelper');
+
+var _devapp = require('./devapp');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _curlirize2.default)(_axios2.default);
+
+describe('Testing curlirize', function () {
+  it('should return a 200 with the value \'world\'', function (done) {
+    _axios2.default.post('http://localhost:7500/', { dummy: 'data' }).then(function (res) {
+      (0, _expect2.default)(res.status).toBe(200);
+      (0, _expect2.default)(res.data.hello).toBe('world');
+      done();
+    }).catch(function (err) {
+      console.error(err);
+    });
+  });
+
+  it('should return a generated command with XML as data', function (done) {
+    _axios2.default.post('http://localhost:7500', "<myTestTag></myTestTag>").then(function (res) {
+      (0, _expect2.default)(res.config.curlObject.getBody()).toBe("--data '<myTestTag></myTestTag>'");
+      (0, _expect2.default)(res.config.curlCommand).toContain("<myTestTag></myTestTag>");
+      done();
+    }).catch(function (err) {
+      console.error(err);
+    });
+  });
+
+  it('should return the response with the defined curl command', function (done) {
+    _axios2.default.post('http://localhost:7500/', { dummy: 'data' }).then(function (res) {
+      (0, _expect2.default)(res.config.curlCommand).toBeDefined();
+      (0, _expect2.default)(res.config.curlCommand).toBe('curl -X POST -H "Content-Type:application/x-www-form-urlencoded" --data \'{"dummy":"data"}\' "http://localhost:7500/"');
+      done();
+    }).catch(function (err) {
+      console.error(err);
+    });
+  });
+
+  it('should return the generated command with no --data attribute', function (done) {
+    _axios2.default.post('http://localhost:7500/').then(function (res) {
+      (0, _expect2.default)(res.config.curlCommand).toBeDefined();
+      (0, _expect2.default)(res.config.curlCommand).toBe('curl -X POST -H "Content-Type:application/x-www-form-urlencoded" "http://localhost:7500/"');
+      done();
+    }).catch(function (err) {
+      console.error(err);
+    });
+  });
+
+  it('should return the generated command with headers specified on method call', function (done) {
+    _axios2.default.post('http://localhost:7500/', {}, { headers: { Authorization: 'Bearer 123', testHeader: 'Testing' } }).then(function (res) {
+      (0, _expect2.default)(res.config.curlCommand).toBeDefined();
+      (0, _expect2.default)(res.config.curlCommand).toBe('curl -X POST -H \"Content-Type:application/x-www-form-urlencoded\" -H \"Authorization:Bearer 123\" -H \"testHeader:Testing\" "http://localhost:7500/"');
+      done();
+    }).catch(function (err) {
+      console.error(err);
+    });
+  });
+
+  it('should return the generated command with a queryString specified in the URL', function (done) {
+    _axios2.default.post('http://localhost:7500/', {}, { params: { test: 1 } }).then(function (res) {
+      (0, _expect2.default)(res.config.curlCommand).toBeDefined();
+      (0, _expect2.default)(res.config.curlCommand).toBe('curl -X POST -H \"Content-Type:application/x-www-form-urlencoded\" "http://localhost:7500?test=1"');
+      done();
+    }).catch(function (err) {
+      console.error(err);
+    });
+  });
+});
+
+describe('Testing curl-helper module', function () {
+  var fakeConfig = {
+    adapter: function adapter() {
+      return 'dummy';
+    },
+    transformRequest: { '0': function _() {
+        return 'dummy';
+      } },
+    transformResponse: { '0': function _() {
+        return 'dummy';
+      } },
+    timeout: 0,
+    xsrfCookieName: 'XSRF-TOKEN',
+    xsrfHeaderName: 'X-XSRF-TOKEN',
+    maxContentLength: -1,
+    validateStatus: function validateStatus() {
+      return 'dummy';
+    },
+    headers: { Accept: 'application/json, text/plain, */*', 'Content-Type': 'application/json;charset=utf-8' },
+    method: 'post',
+    url: 'http://localhost:7500/',
+    data: { dummy: 'data' },
+    params: { testParam: 'test1', testParam_two: "test2" }
+  };
+  var curl = new _CurlHelper.CurlHelper(fakeConfig);
+
+  it('should return an empty string if data is undefined', function (done) {
+    var emptyConfig = {
+      adapter: function adapter() {
+        return 'dummy';
+      },
+      transformRequest: { '0': function _() {
+          return 'dummy';
+        } },
+      transformResponse: { '0': function _() {
+          return 'dummy';
+        } },
+      timeout: 0,
+      xsrfCookieName: 'XSRF-TOKEN',
+      xsrfHeaderName: 'X-XSRF-TOKEN',
+      maxContentLength: -1,
+      validateStatus: function validateStatus() {
+        return 'dummy';
+      },
+      headers: { Accept: 'application/json, text/plain, */*', 'Content-Type': 'application/json;charset=utf-8' },
+      method: 'post',
+      url: 'http://localhost:7500/',
+      data: undefined
+    };
+    var emptyDataCurl = new _CurlHelper.CurlHelper(emptyConfig);
+    (0, _expect2.default)(emptyDataCurl.getBody()).toBe('');
+    done();
+  });
+
+  it('should return an empty string if data is == empty string', function (done) {
+    var emptyConfig = {
+      adapter: function adapter() {
+        return 'dummy';
+      },
+      transformRequest: { '0': function _() {
+          return 'dummy';
+        } },
+      transformResponse: { '0': function _() {
+          return 'dummy';
+        } },
+      timeout: 0,
+      xsrfCookieName: 'XSRF-TOKEN',
+      xsrfHeaderName: 'X-XSRF-TOKEN',
+      maxContentLength: -1,
+      validateStatus: function validateStatus() {
+        return 'dummy';
+      },
+      headers: { Accept: 'application/json, text/plain, */*', 'Content-Type': 'application/json;charset=utf-8' },
+      method: 'post',
+      url: 'http://localhost:7500/',
+      data: ''
+    };
+    var emptyDataCurl = new _CurlHelper.CurlHelper(emptyConfig);
+    (0, _expect2.default)(emptyDataCurl.getBody()).toBe('');
+    done();
+  });
+
+  it('should return an empty string if data is == {}', function (done) {
+    var emptyConfig = {
+      adapter: function adapter() {
+        return 'dummy';
+      },
+      transformRequest: { '0': function _() {
+          return 'dummy';
+        } },
+      transformResponse: { '0': function _() {
+          return 'dummy';
+        } },
+      timeout: 0,
+      xsrfCookieName: 'XSRF-TOKEN',
+      xsrfHeaderName: 'X-XSRF-TOKEN',
+      maxContentLength: -1,
+      validateStatus: function validateStatus() {
+        return 'dummy';
+      },
+      headers: { Accept: 'application/json, text/plain, */*', 'Content-Type': 'application/json;charset=utf-8' },
+      method: 'post',
+      url: 'http://localhost:7500/',
+      data: {}
+    };
+    var emptyDataCurl = new _CurlHelper.CurlHelper(emptyConfig);
+    (0, _expect2.default)(emptyDataCurl.getBody()).toBe('');
+    done();
+  });
+
+  it('should return a string with headers', function (done) {
+    (0, _expect2.default)(curl.getHeaders()).toBe('-H "Accept:application/json, text/plain, */*" -H "Content-Type:application/json;charset=utf-8"');
+    done();
+  });
+
+  it('should return a string with HTTP method', function (done) {
+    (0, _expect2.default)(curl.getMethod()).toBe('-X POST');
+    done();
+  });
+
+  it('should return a string with request body', function (done) {
+    (0, _expect2.default)(curl.getBody()).toBe('--data \'{"dummy":"data"}\'');
+    done();
+  });
+
+  it('should return the URL of the request', function (done) {
+    (0, _expect2.default)(curl.getUrl()).toBe("http://localhost:7500/");
+    done();
+  });
+
+  it('should return the queryString of the request', function (done) {
+    (0, _expect2.default)(curl.getQueryString()).toBe("?testParam=test1&testParam_two=test2");
+    done();
+  });
+});

--- a/dist/test/devapp.js
+++ b/dist/test/devapp.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var _express = require('express');
+
+var _express2 = _interopRequireDefault(_express);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var app = (0, _express2.default)();
+
+app.get('/', function (req, res) {
+  res.send({ hello: 'world' });
+});
+
+app.post('/', function (req, res) {
+  res.send({ hello: 'world' });
+});
+
+app.listen(7500, function () {
+  console.info('Express dev server listening on port 7500');
+});
+
+module.exports.app;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const ES6 = require('./src/curlirize');
 const { default: CommonJS } = require('./dist/curlirize');
-module.exports = typeof process === 'object' ? CommonJS : ES6;
+module.exports =
+  typeof process === 'object' ? CommonJS : require('./src/curlirize');

--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
-module.exports = require('./src/curlirize');
+const ES6 = require('./src/curlirize');
+const { default: CommonJS } = require('./dist/curlirize');
+module.exports = typeof process === 'object' ? CommonJS : ES6;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "curlirize-for-axios",
-  "version": "1.4.0",
-  "description": "Axios third-party module to print all axios requests as curl commands in the console.",
+  "name": "axios-to-curl",
+  "version": "1.3.4",
+  "description": "Axios third-party module to print all axios requests as curl commands in the console. This repository is forked from axios-curlirize <https://www.npmjs.com/package/axios-curlirize> and supports use with Node JS without having to enable ES6 imports. This repo was inspired by an issue <https://github.com/delirius325/axios-curlirize/issues/20> raised on the origional repository <https://github.com/delirius325/axios-curlirize>. Special thanks to Anthony Gauthier <https://github.com/delirius325>, the author of axios-curlirize",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
@@ -16,15 +16,11 @@
     "curl",
     "debug"
   ],
-  "author": "delirius325",
+  "author": "Abhishek Rajeshirke <https://github.com/colidarity>",
   "contributors": [
     {
-      "name": "Justin \"jayceekay\"",
-      "url": "https://github.com/jayceekay"
-    },
-    {
-      "name": "Peter \"binggg\" Zhao",
-      "url": "https://github.com/binggg"
+      "name": "Abhishek Rajeshirke",
+      "url": "https://github.com/colidarity"
     }
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,9 @@
     "url": "https://github.com/delirius325/axios-curlirize/issues"
   },
   "homepage": "https://github.com/delirius325/axios-curlirize#readme",
-  "dependencies": {
-    "axios": ">=0.19.0"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "axios": ">=0.19.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "axios-to-curl",
-  "version": "1.3.4",
+  "name": "axios-curlirize",
+  "version": "1.3.3",
   "description": "Axios third-party module to print all axios requests as curl commands in the console. This repository is forked from axios-curlirize <https://www.npmjs.com/package/axios-curlirize> and supports use with Node JS without having to enable ES6 imports. This repo was inspired by an issue <https://github.com/delirius325/axios-curlirize/issues/20> raised on the origional repository <https://github.com/delirius325/axios-curlirize>. Special thanks to Anthony Gauthier <https://github.com/delirius325>, the author of axios-curlirize",
   "main": "index.js",
   "scripts": {
@@ -16,10 +16,18 @@
     "curl",
     "debug"
   ],
-  "author": "Abhishek Rajeshirke <https://github.com/colidarity>",
+  "author": "delirius325",
   "contributors": [
     {
-      "name": "Abhishek Rajeshirke",
+      "name": "Justin \"jayceekay\"",
+      "url": "https://github.com/jayceekay"
+    },
+    {
+      "name": "Peter \"binggg\" Zhao",
+      "url": "https://github.com/binggg"
+    },
+    {
+      "name": "Abhishek Rajeshirke <arajeshirke79@gmail.com>",
       "url": "https://github.com/colidarity"
     }
   ],
@@ -29,8 +37,7 @@
   },
   "homepage": "https://github.com/delirius325/axios-curlirize#readme",
   "dependencies": {
-    "axios": ">=0.19.0",
-    "express": "^4.16.3"
+    "axios": ">=0.19.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -38,6 +45,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "expect": "^23.1.0",
+    "express": "^4.16.3",
     "mocha": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "axios-curlirize",
-  "version": "1.3.3",
+  "name": "curlirize-for-axios",
+  "version": "1.4.0",
   "description": "Axios third-party module to print all axios requests as curl commands in the console.",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
-    "preinstall": "yarn install",
-    "postinstall": "if [ -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi"
+    "prepare": "if [ -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi"
   },
   "repository": {
     "type": "git",
@@ -33,15 +32,16 @@
     "url": "https://github.com/delirius325/axios-curlirize/issues"
   },
   "homepage": "https://github.com/delirius325/axios-curlirize#readme",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "axios": ">=0.19.0",
-    "expect": "^23.1.0",
-    "express": "^4.16.3",
-    "mocha": "^5.2.0",
+    "express": "^4.16.3"
+  },
+  "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",
-    "babel-preset-env": "^1.6.1"
+    "babel-preset-env": "^1.6.1",
+    "expect": "^23.1.0",
+    "mocha": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
+    "preinstall": "yarn install",
     "postinstall": "if [ -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi"
   },
   "repository": {


### PR DESCRIPTION
# Why this PR?

- Node uses common JS syntax for imports. This plugin uses an ES6 import statement which works fine on a browser but fails on a node server unless it is run with an --experimental-modules flag.

- This PR makes this package node compatible.

# What was the problem? 

- Babel binary in the post-install script was not found because babel was never installed by NPM, babel being a part of dev-dependencies. For babel to be installed by NPM as a part of module dependency it has to be mentioned as a dependency. 

- Path to babel binary was wrong.

# What changed?

- Moved the post-install script to the prepare hook so CommonJS code is ready in the dist folder on pre-publish.

- index file changed to serve either src ot dist folder based on if the package is being used on a browser or nodeJS.
