### PR TITLE
Add option to omit callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,20 @@ app.listen(7500, () => {
     });
 });
 ```
+
+# Disable the logger
+
+By default, all requests will be logged. But you can disable this behaviour unitarily by setting the `curlirize` option to false within the axios request.
+
+```javascript
+axios
+  .post('http://localhost:7500/', { dummy: 'data' }, {
+    curlirize: false
+  })
+  .then(res => {
+    console.log('success');
+  })
+  .catch(err => {
+    console.log(err);
+  });
+```

--- a/dist/curlirize.js
+++ b/dist/curlirize.js
@@ -1,10 +1,10 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _CurlHelper = require('./lib/CurlHelper');
+var _CurlHelper = require("./lib/CurlHelper");
 
 // thanks to https://github.com/uyu423
 function defaultLogCallback(curlResult, err) {
@@ -29,10 +29,12 @@ exports.default = function (instance) {
       // Even if the axios middleware is stopped, no error should occur outside.
       callback(null, err);
     } finally {
-      callback({
-        command: req.curlCommand,
-        object: req.curlObject
-      });
+      if (req.curlirize !== false) {
+        callback({
+          command: req.curlCommand,
+          object: req.curlObject
+        });
+      }
       return req;
     }
   });

--- a/src/curlirize.js
+++ b/src/curlirize.js
@@ -20,10 +20,12 @@ export default (instance, callback = defaultLogCallback) => {
       // Even if the axios middleware is stopped, no error should occur outside.
       callback(null, err);
     } finally {
-      callback({
-        command: req.curlCommand,
-        object: req.curlObject,
-      });
+      if (req.curlirize !== false) {
+        callback({
+          command: req.curlCommand,
+          object: req.curlObject
+        });
+      }
       return req;
     }
   });


### PR DESCRIPTION
I wanted to use your package to help me debug my servers, but then I saw that it is not possible to omit certain requests.

For example: I wouldn't want my auth request to be fully logged because of the credentials they uses !

So I made this small change that allow any request to disable the callback. I found no way to test if the callback was called or not but it was tested on my machine.