### PR TITLE
Update CurlHelper.js

### DIFF
--- a/src/lib/CurlHelper.js
+++ b/src/lib/CurlHelper.js
@@ -54,6 +54,9 @@ export class CurlHelper {
   }
 
   getUrl() {
+    if (this.request.baseURL) {
+      return this.request.baseURL + "/" + this.request.url;
+    }
     return this.request.url
   }
 


### PR DESCRIPTION
The variable baseURL wasn't taken into account, so the curl command prints out just the relative part of the url even if baseURL is configured.