### PR TITLE
Add a function to clear the config object - Fix #37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ typings/
 # next.js build output
 .next
 
+#jetbrains ide
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+src/test
+dist/test
+.circleci
+.github
+codecov.yml
+.releaserc
+.idea
+*.tgz

--- a/README.md
+++ b/README.md
@@ -97,9 +97,7 @@ axios
 
 ```javascript
 axios
-  .post('http://localhost:7500/', { dummy: 'data' }, {
-    curlirize: false
-  })
+  .post('http://localhost:7500/', { dummy: 'data' })
   .then(res => {
     res.config.clearCurl();
   })

--- a/README.md
+++ b/README.md
@@ -92,3 +92,18 @@ axios
     console.log(err);
   });
 ```
+
+# Clear a request
+
+```javascript
+axios
+  .post('http://localhost:7500/', { dummy: 'data' }, {
+    curlirize: false
+  })
+  .then(res => {
+    res.config.clearCurl();
+  })
+  .catch(err => {
+    console.log(err);
+  });
+```

--- a/dist/curlirize.js
+++ b/dist/curlirize.js
@@ -24,8 +24,14 @@ exports.default = function (instance) {
       var curl = new _CurlHelper.CurlHelper(req);
       req.curlObject = curl;
       req.curlCommand = curl.generateCommand();
+      req.clearCurl = function () {
+        delete req.curlObject;
+        delete req.curlCommand;
+        delete req.clearCurl;
+      };
     } catch (err) {
       // Even if the axios middleware is stopped, no error should occur outside.
+      console.log(err);
       callback(null, err);
     } finally {
       if (req.curlirize !== false) {

--- a/dist/lib/CurlHelper.js
+++ b/dist/lib/CurlHelper.js
@@ -50,9 +50,7 @@ var CurlHelper = exports.CurlHelper = function () {
   }, {
     key: "getBody",
     value: function getBody() {
-      if (typeof this.request.data !== "undefined" && this.request.data !== "" && this.request.data !== null &&
-      //Object.keys(this.request.data).length &&
-      this.request.method.toUpperCase() !== "GET") {
+      if (typeof this.request.data !== "undefined" && this.request.data !== "" && this.request.data !== null && this.request.method.toUpperCase() !== "GET") {
         var data = _typeof(this.request.data) === "object" || Object.prototype.toString.call(this.request.data) === "[object Array]" ? JSON.stringify(this.request.data) : this.request.data;
         return ("--data '" + data + "'").trim();
       } else {

--- a/dist/test/curlirize.test.js
+++ b/dist/test/curlirize.test.js
@@ -30,6 +30,19 @@ describe('Testing curlirize', function () {
       console.error(err);
     });
   });
+  it('should allow to remove curlirize part on a request', function (done) {
+    _axios2.default.post('http://localhost:7500/', { dummy: 'data' }).then(function (res) {
+      (0, _expect2.default)(res.status).toBe(200);
+      (0, _expect2.default)(res.data.hello).toBe('world');
+      res.config.clearCurl();
+      (0, _expect2.default)(res.config.curlObject).not.toBeDefined();
+      (0, _expect2.default)(res.config.curlCommand).not.toBeDefined();
+      (0, _expect2.default)(res.config.clearCurl).not.toBeDefined();
+      done();
+    }).catch(function (err) {
+      console.error(err);
+    });
+  });
 
   it('should return a generated command with XML as data', function (done) {
     _axios2.default.post('http://localhost:7500', "<myTestTag></myTestTag>").then(function (res) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
-    "prepare": "babel ./src --experimental --source-maps-inline -d ./dist"
+    "prepare": "if [ -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist && export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha --exit dist/test/*.test.js",
-    "prepare": "if [ -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi"
+    "prepare": "babel ./src --experimental --source-maps-inline -d ./dist"
   },
   "repository": {
     "type": "git",

--- a/src/curlirize.js
+++ b/src/curlirize.js
@@ -22,7 +22,6 @@ export default (instance, callback = defaultLogCallback) => {
       }
     } catch (err) {
       // Even if the axios middleware is stopped, no error should occur outside.
-      console.log(err);
       callback(null, err);
     } finally {
       if (req.curlirize !== false) {

--- a/src/curlirize.js
+++ b/src/curlirize.js
@@ -15,8 +15,14 @@ export default (instance, callback = defaultLogCallback) => {
       const curl = new CurlHelper(req);
       req.curlObject = curl;
       req.curlCommand = curl.generateCommand();
+      req.clearCurl = () => {
+        delete req.curlObject;
+        delete req.curlCommand;
+        delete req.clearCurl;
+      }
     } catch (err) {
       // Even if the axios middleware is stopped, no error should occur outside.
+      console.log(err);
       callback(null, err);
     } finally {
       if (req.curlirize !== false) {

--- a/src/test/curlirize.test.js
+++ b/src/test/curlirize.test.js
@@ -10,14 +10,29 @@ curlirize(axios);
 describe('Testing curlirize', () => {
   it('should return a 200 with the value \'world\'', done => {
     axios.post('http://localhost:7500/', { dummy: 'data' })
-      .then(res => {
-        expect(res.status).toBe(200);
-        expect(res.data.hello).toBe('world');
-        done();
-      })
-      .catch(err => {
-        console.error(err);
-      });
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.data.hello).toBe('world');
+          done();
+        })
+        .catch(err => {
+          console.error(err);
+        });
+  });
+  it('should allow to remove curlirize part on a request', done => {
+    axios.post('http://localhost:7500/', { dummy: 'data' })
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.data.hello).toBe('world');
+          res.config.clearCurl();
+          expect(res.config.curlObject).not.toBeDefined()
+          expect(res.config.curlCommand).not.toBeDefined()
+          expect(res.config.clearCurl).not.toBeDefined()
+          done();
+        })
+        .catch(err => {
+          console.error(err);
+        });
   });
 
   it('should return a generated command with XML as data', done => {


### PR DESCRIPTION
Not really sure how you work, but I try to add a little function to clean the config .

Some remarks : 
 - I can't run the function prepare, my computer (windows), doesn't recognize the -e , so I just replace
```
if [ -e ./node_modules/.bin/babel ]; then ./node_modules/.bin/babel ./src --experimental --source-maps-inline -d ./dist; fi
```
by
```
babel ./src --experimental --source-maps-inline -d ./dist
```
To do my tests

- i've added an npmignore to remove some files on the npm packages .

Fix #37 